### PR TITLE
feat: Parse a task status from a string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env

--- a/content/tasks.go
+++ b/content/tasks.go
@@ -1,5 +1,7 @@
 package content
 
+import "strings"
+
 // TaskStatus is the type of a task.
 type TaskStatus int
 
@@ -36,6 +38,42 @@ type TaskMarker struct {
 func NewTaskMarker(t TaskStatus) *TaskMarker {
 	return &TaskMarker{
 		Status: t,
+	}
+}
+
+// ParseTaskStatus parses a task status from a TO DO/DOING/DONE/etc. string.
+func ParseTaskStatus(status string) TaskStatus {
+	caseInsensitiveStatus := strings.ToUpper(status)
+	switch caseInsensitiveStatus {
+	case "TODO":
+		return TaskStatusTodo
+	case "DONE":
+		return TaskStatusDone
+	case "DOING":
+		return TaskStatusDoing
+	case "LATER":
+		return TaskStatusLater
+	case "NOW":
+		return TaskStatusNow
+	case "CANCELLED":
+		return TaskStatusCancelled
+	case "CANCELED":
+		return TaskStatusCanceled
+	case "IN-PROGRESS":
+		return TaskStatusInProgress
+	case "WAIT":
+		return TaskStatusWait
+	case "WAITING":
+		return TaskStatusWaiting
+	default:
+		return TaskStatusNone
+	}
+}
+
+// NewTaskMarkerFromString creates a new task marker from a TO DO/DOING/DONE/etc. string.
+func NewTaskMarkerFromString(t string) *TaskMarker {
+	return &TaskMarker{
+		Status: ParseTaskStatus(t),
 	}
 }
 

--- a/content/tasks_test.go
+++ b/content/tasks_test.go
@@ -1,0 +1,34 @@
+package content_test
+
+import (
+	"github.com/aholstenson/logseq-go/content"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Task status", func() {
+	DescribeTable("can be parsed from strings",
+		func(input string, expectedStatus content.TaskStatus) {
+			taskMarker := content.NewTaskMarkerFromString(input)
+			Expect(taskMarker.Status).To(Equal(expectedStatus))
+		},
+		Entry("TODO", "todo", content.TaskStatusTodo),
+		Entry("DONE", "done", content.TaskStatusDone),
+		Entry("DOING", "doing", content.TaskStatusDoing),
+		Entry("LATER", "LATER", content.TaskStatusLater),
+		Entry("NOW", "NOW", content.TaskStatusNow),
+		Entry("CANCELLED", "CANCELLED", content.TaskStatusCancelled),
+		Entry("CANCELED", "CANCELED", content.TaskStatusCanceled),
+		Entry("IN-PROGRESS", "IN-PROGRESS", content.TaskStatusInProgress),
+		Entry("WAIT", "WAIT", content.TaskStatusWait),
+		Entry("WAITING", "WAITING", content.TaskStatusWaiting),
+	)
+
+	DescribeTable("returns an error for invalid input",
+		func(invalidInput string) {
+			taskMarker := content.NewTaskMarkerFromString(invalidInput)
+			Expect(taskMarker.Status).To(Equal(content.TaskStatusNone))
+		},
+		Entry("Invalid input", "Invalid"),
+		Entry("Empty input", ""))
+})

--- a/internal/markdown/parsing.go
+++ b/internal/markdown/parsing.go
@@ -288,29 +288,8 @@ func convertTaskMarker(node *content.Paragraph) {
 		potentialMarker = textNode.Value[:potentialMarkerIdx]
 	}
 
-	var taskStatus content.TaskStatus
-	switch potentialMarker {
-	case "TODO":
-		taskStatus = content.TaskStatusTodo
-	case "DONE":
-		taskStatus = content.TaskStatusDone
-	case "DOING":
-		taskStatus = content.TaskStatusDoing
-	case "LATER":
-		taskStatus = content.TaskStatusLater
-	case "NOW":
-		taskStatus = content.TaskStatusNow
-	case "CANCELLED":
-		taskStatus = content.TaskStatusCancelled
-	case "CANCELED":
-		taskStatus = content.TaskStatusCanceled
-	case "IN-PROGRESS":
-		taskStatus = content.TaskStatusInProgress
-	case "WAIT":
-		taskStatus = content.TaskStatusWait
-	case "WAITING":
-		taskStatus = content.TaskStatusWaiting
-	default:
+	taskStatus := content.ParseTaskStatus(potentialMarker)
+	if taskStatus == content.TaskStatusNone {
 		return
 	}
 


### PR DESCRIPTION
Hey! First, thanks for this useful package!

I'm writing a CLI that will parse strings like `--task TODO`, hence I added a public function instead of doing it in my repo.